### PR TITLE
Fixes Xcode 6.1 optional inits, fixes unit test error messages

### DIFF
--- a/JSONHelper/Pod Classes/JSONHelper.swift
+++ b/JSONHelper/Pod Classes/JSONHelper.swift
@@ -145,8 +145,10 @@ public func <<<(inout property: NSURL, value: AnyObject?) -> NSURL {
     var didDeserialize = false
 
     if let stringURL = value >>> JSONString {
-        property = NSURL(string: stringURL)
-        didDeserialize = true
+        if let prop = NSURL(string: stringURL) {
+            property = prop
+            didDeserialize = true
+        }
     }
 
     if !didDeserialize {
@@ -372,7 +374,9 @@ public func <<<*(inout array: [NSURL]?, value: AnyObject?) -> [NSURL]? {
         didDeserialize = true
 
         for stringURL in stringURLArray {
-            array!.append(NSURL(string: stringURL))
+            if let url = NSURL(string: stringURL) {
+                array!.append(url)
+            }
         }
     } else {
         array = nil
@@ -393,7 +397,9 @@ public func <<<*(inout array: [NSURL], value: AnyObject?) -> [NSURL] {
         didDeserialize = true
 
         for stringURL in stringURLArray {
-            array.append(NSURL(string: stringURL))
+            if let url = NSURL(string: stringURL) {
+                array.append(url)
+            }
         }
     }
 

--- a/JSONHelperTests/JSONHelperTests.swift
+++ b/JSONHelperTests/JSONHelperTests.swift
@@ -60,30 +60,30 @@ class JSONHelperTests: XCTestCase {
 
     // Test different deserializations.
     func testString() {
-        XCTAssert(result.stringVal == "a", "result.stringVal should equal 'a'")
+        XCTAssertEqual(result.stringVal!, "a", "result.stringVal should equal 'a'")
     }
 
     func testDefaultableString() {
-        XCTAssert(result.defaultableString == "default", "result.defaultableString should equal 'default'")
-        XCTAssert(resultWithChangedDefaults.defaultableString == "not default", "resultWithChangedDefaults.defaultableString should equal 'not default'")
+        XCTAssertEqual(result.defaultableString, "default", "result.defaultableString should equal 'default'")
+        XCTAssertEqual(resultWithChangedDefaults.defaultableString, "not default", "resultWithChangedDefaults.defaultableString should equal 'not default'")
     }
     
     func testInt() {
-        XCTAssert(result.intVal == 1, "result.intVal should equal 1")
+        XCTAssertEqual(result.intVal!, 1, "result.intVal should equal 1")
     }
 
     func testDefaultableInt() {
-        XCTAssert(result.defaultableInt == 91, "result.defaultableInt should equal 91")
-        XCTAssert(resultWithChangedDefaults.defaultableInt == 99, "resultWithChangedDefaults.defaultableInt should equal 99")
+        XCTAssertEqual(result.defaultableInt, 91, "result.defaultableInt should equal 91")
+        XCTAssertEqual(resultWithChangedDefaults.defaultableInt, 99, "resultWithChangedDefaults.defaultableInt should equal 99")
     }
 
     func testBool() {
-        XCTAssert(result.boolVal == true, "result.boolVal should be true")
+        XCTAssertEqual(result.boolVal!, true, "result.boolVal should be true")
     }
 
     func testDefaultableBool() {
-        XCTAssert(result.defaultableBool == true, "result.defaultableBool should be true")
-        XCTAssert(resultWithChangedDefaults.defaultableBool == false, "resultWithChangedDefaults.defaultableBool should be false")
+        XCTAssertEqual(result.defaultableBool, true, "result.defaultableBool should be true")
+        XCTAssertEqual(resultWithChangedDefaults.defaultableBool, false, "resultWithChangedDefaults.defaultableBool should be false")
     }
 
     func testDate() {
@@ -92,7 +92,7 @@ class JSONHelperTests: XCTestCase {
 
         let testDate = dateFormatter.dateFromString("2014-09-19")
 
-        XCTAssert(result.dateVal!.compare(testDate!) == NSComparisonResult.OrderedSame, "result.dateVal should be 2014-09-19")
+        XCTAssertEqual(result.dateVal!.compare(testDate!), NSComparisonResult.OrderedSame, "result.dateVal should be 2014-09-19")
     }
 
     func testDefaultableDate() {
@@ -101,36 +101,36 @@ class JSONHelperTests: XCTestCase {
 
         let testDate = dateFormatter.dateFromString("2015-09-19")
 
-        XCTAssert(resultWithChangedDefaults.defaultableDate.compare(testDate!) == NSComparisonResult.OrderedSame, "resultWithChangedDefaults.defaultableDate should be 2015-09-19")
+        XCTAssertEqual(resultWithChangedDefaults.defaultableDate.compare(testDate!), NSComparisonResult.OrderedSame, "resultWithChangedDefaults.defaultableDate should be 2015-09-19")
     }
 
     func testURL() {
-        XCTAssert(result.urlVal!.host == "github.com", "result.urlVal's host should be github.com")
+        XCTAssertEqual(result.urlVal!.host!, "github.com", "result.urlVal's host should be github.com")
     }
 
     func testDefaultableURL() {
-        XCTAssert(result.defaultableURL.host == "google.com", "result.defaultableURL's host should be google.com")
-        XCTAssert(resultWithChangedDefaults.defaultableURL.host == "quora.com", "resultWithChangedDefaults.defaultableURL's host should be quora.com")
+        XCTAssertEqual(result.defaultableURL.host!, "google.com", "result.defaultableURL's host should be google.com")
+        XCTAssertEqual(resultWithChangedDefaults.defaultableURL.host!, "quora.com", "resultWithChangedDefaults.defaultableURL's host should be quora.com")
     }
 
     func testStringArray() {
-        XCTAssert(result.stringArrayVal?.count == 3, "result.stringArrayVal should have 3 members")
+        XCTAssertEqual(result.stringArrayVal!.count, 3, "result.stringArrayVal should have 3 members")
     }
 
     func testIntArray() {
-        XCTAssert(result.intArrayVal?.count == 5, "result.intArrayVal should have 5 members")
+        XCTAssertEqual(result.intArrayVal!.count, 5, "result.intArrayVal should have 5 members")
     }
 
     func testBoolArray() {
-        XCTAssert(result.boolArrayVal?.count == 3, "result.boolArrayVal should have 3 members")
+        XCTAssertEqual(result.boolArrayVal!.count, 3, "result.boolArrayVal should have 3 members")
     }
 
     func testInstance() {
-        XCTAssert(result.instanceVal?.stringVal == "Mark", "result.instanceVal?.stringVal should equal 'Mark'")
+        XCTAssertEqual(result.instanceVal!.stringVal!, "Mark", "result.instanceVal?.stringVal should equal 'Mark'")
     }
 
     func testInstanceArray() {
-        XCTAssert(result.instanceArrayVal?.count == 2, "result.instanceArrayVal should have 2 members")
+        XCTAssertEqual(result.instanceArrayVal!.count, 2, "result.instanceArrayVal should have 2 members")
     }
 
     func testJSONStringParsing() {
@@ -152,6 +152,6 @@ class JSONHelperTests: XCTestCase {
             areYouGroot += person.name
         }
 
-        XCTAssert(areYouGroot == "I am Groot!", "Groot should be Groot")
+        XCTAssertEqual(areYouGroot, "I am Groot!", "Groot should be Groot")
     }
 }

--- a/JSONHelperTests/Models/TestModel.swift
+++ b/JSONHelperTests/Models/TestModel.swift
@@ -18,7 +18,7 @@ class TestModel: Deserializable {
     var dateVal: NSDate?
     var defaultableDate = NSDate()
     var urlVal: NSURL?
-    var defaultableURL = NSURL(string: "http://google.com/")
+    var defaultableURL = NSURL(string: "http://google.com/")!
     var stringArrayVal: [String]?
     var intArrayVal: [Int]?
     var boolArrayVal: [Bool]?


### PR DESCRIPTION
For the unit test changes:
Uses `XCTAssertEqual` for most of the tests instead of `XCTAssert`, since `XCTAssertEqual` produces better error messages for simple equality assertions, namely, it shows what the result actually was, as well as what it was expecting it to be.

For Xcode 6.1:
It simply implicitly unwraps the failing initialiser optionals where it makes sense to do so (mostly in the tests), but it uses `if let` in the deserialisation code.
