### PR TITLE
- Handle special case where we want an Int, but the JSON returns a String

### DIFF
--- a/JSONHelper/Pod Classes/JSONHelper.swift
+++ b/JSONHelper/Pod Classes/JSONHelper.swift
@@ -94,6 +94,14 @@ public func <<<<T>(inout property: T?, value: AnyObject?) -> T? {
             didDeserialize = true
         } else {
             property = nil
+            
+            // Special case where the passed in value is a String,
+            // but we really want it to be an Int
+            if let convertedValue = unwrappedValue as? String {
+                if let newValue = convertedValue.toInt() as? T {
+                    property = newValue
+                }
+            }
         }
     } else {
         property = nil


### PR DESCRIPTION
I'm finding that sometimes JSON returns an integer wrapped in a string. JSONHelper won't convert it into an Int. This pull request handles the case where the JSON can't be cast to an Int, but can be cast to a String and then the String can be converted to an Int.
