### PR TITLE
Revert "Adding support for dictionaries, in addition to arrays"

### DIFF
--- a/JSONHelper.xcodeproj/project.pbxproj
+++ b/JSONHelper.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		5FAD07691A70F2FC00C4D09E /* JSONHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSONHelper.h; sourceTree = "<group>"; };
 		5FAD076F1A70F2FC00C4D09E /* JSONHelperTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JSONHelperTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FAD07751A70F2FC00C4D09E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		5FAD07761A70F2FC00C4D09E /* JSONHelperTests.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = JSONHelperTests.swift; sourceTree = "<group>"; tabWidth = 2; };
+		5FAD07761A70F2FC00C4D09E /* JSONHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelperTests.swift; sourceTree = "<group>"; };
 		5FAD07841A70F31300C4D09E /* JSONHelperExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = JSONHelperExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FAD07871A70F31300C4D09E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5FAD07881A70F31300C4D09E /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -53,7 +53,7 @@
 		5FAD07981A70F31300C4D09E /* JSONHelperExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JSONHelperExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FAD079D1A70F31300C4D09E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5FAD079E1A70F31300C4D09E /* JSONHelperExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONHelperExampleTests.swift; sourceTree = "<group>"; };
-		5FC4468E1A70F3750038EE4E /* JSONHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; tabWidth = 2; };
+		5FC4468E1A70F3750038EE4E /* JSONHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/JSONHelper/JSONHelper.swift
+++ b/JSONHelper/JSONHelper.swift
@@ -40,20 +40,12 @@ public func JSONStrings(object: AnyObject?) -> [String]? {
   return object as? [String]
 }
 
-public func JSONStringsMap(object: AnyObject?) -> [String: String]? {
-    return object as? [String: String]
-}
-
 public func JSONInt(object: AnyObject?) -> Int? {
   return object as? Int
 }
 
 public func JSONInts(object: AnyObject?) -> [Int]? {
   return object as? [Int]
-}
-
-public func JSONIntsMap(object: AnyObject?) -> [String: Int]? {
-    return object as? [String: Int]
 }
 
 public func JSONBool(object: AnyObject?) -> Bool? {
@@ -64,16 +56,8 @@ public func JSONBools(object: AnyObject?) -> [Bool]? {
   return object as? [Bool]
 }
 
-public func JSONBoolsMap(object: AnyObject?) -> [String: Bool]? {
-    return object as? [String: Bool]
-}
-
 public func JSONArray(object: AnyObject?) -> [AnyObject]? {
   return object as? [AnyObject]
-}
-
-public func JSONArraysMap(object: AnyObject?) -> [String: [AnyObject]]? {
-    return object as? [String: [AnyObject]]
 }
 
 public func JSONObject(object: AnyObject?) -> [String: AnyObject]? {
@@ -82,10 +66,6 @@ public func JSONObject(object: AnyObject?) -> [String: AnyObject]? {
 
 public func JSONObjects(object: AnyObject?) -> [[String: AnyObject]]? {
   return object as? [[String: AnyObject]]
-}
-
-public func JSONObjectsMap(object: AnyObject?) -> [String: [String: AnyObject]]? {
-    return object as? [String: [String: AnyObject]]
 }
 
 // Operator for use in "if let" conversions.
@@ -336,167 +316,6 @@ public func <<<* (inout array: [NSDate], value: AnyObject?) -> [NSDate] {
   return array
 }
 
-public func <<<* (inout dictionary: [String: String]?, value: AnyObject?) -> [String: String]? {
-
-  if let stringDictionary = value >>> JSONStringsMap {
-    dictionary = stringDictionary
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: String], value: AnyObject?) -> [String: String] {
-  var newValue: [String: String]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Int]?, value: AnyObject?) -> [String: Int]? {
-
-  if let intDictionary = value >>> JSONIntsMap {
-    dictionary = intDictionary
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Int], value: AnyObject?) -> [String: Int] {
-  var newValue: [String: Int]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Float]?, value: AnyObject?) -> [String: Float]? {
-
-  if let floatDictionary = value as? [String: Float] {
-    dictionary = floatDictionary
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Float], value: AnyObject?) -> [String: Float] {
-  var newValue: [String: Float]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Double]?, value: AnyObject?) -> [String: Double]? {
-
-  if let doubleDictionaryDoubleExcitement = value as? [String: Double] {
-    dictionary = doubleDictionaryDoubleExcitement
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Double], value: AnyObject?) -> [String: Double] {
-  var newValue: [String: Double]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Bool]?, value: AnyObject?) -> [String: Bool]? {
-
-  if let boolDictionary = value >>> JSONBoolsMap {
-    dictionary = boolDictionary
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: Bool], value: AnyObject?) -> [String: Bool] {
-  var newValue: [String: Bool]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSURL]?, value: AnyObject?) -> [String: NSURL]? {
-
-  if let stringURLDictionary = value >>> JSONStringsMap {
-    dictionary = [String: NSURL]()
-
-    for (key, stringURL) in stringURLDictionary {
-
-      if let url = NSURL(string: stringURL) {
-        dictionary![key] = url
-      }
-    }
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSURL], value: AnyObject?) -> [String: NSURL] {
-  var newValue: [String: NSURL]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSDate]?, valueAndFormat: (value: AnyObject?, format: AnyObject?)) -> [String: NSDate]? {
-  var newValue: [String: NSDate]?
-
-  if let dateStringDictionary = valueAndFormat.value >>> JSONStringsMap {
-
-    if let formatString = valueAndFormat.format >>> JSONString {
-      let dateFormatter = NSDateFormatter()
-      dateFormatter.dateFormat = formatString
-      newValue = [String: NSDate]()
-
-      for (key, dateString) in dateStringDictionary {
-
-        if let date = dateFormatter.dateFromString(dateString) {
-          newValue![key] = date
-        }
-      }
-    }
-  }
-  dictionary = newValue
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSDate], valueAndFormat: (value: AnyObject?, format: AnyObject?)) -> [String: NSDate] {
-  var newValue: [String: NSDate]?
-  newValue <<<* valueAndFormat
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSDate]?, value: AnyObject?) -> [String: NSDate]? {
-
-  if let timestampsMap = value as? [String: AnyObject] {
-    dictionary = [String: NSDate]()
-
-    for (key, timestamp) in timestampsMap {
-      var date: NSDate?
-      date <<< timestamp
-      if date != nil { dictionary![key] = date! }
-    }
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<* (inout dictionary: [String: NSDate], value: AnyObject?) -> [String: NSDate] {
-  var newValue: [String: NSDate]?
-  newValue <<<* value
-  if let newValue = newValue { dictionary = newValue }
-  return dictionary
-}
-
 // MARK: - Operator for quick class deserialization.
 
 infix operator <<<< { associativity right precedence 150 }
@@ -545,28 +364,6 @@ public func <<<<* <T: Deserializable>(inout array: [T], dataObject: AnyObject?) 
   newArray <<<<* dataObject
   if let newArray = newArray { array = newArray }
   return array
-}
-
-
-public func <<<<* <T: Deserializable>(inout dictionary: [String:T]?, dataObject: AnyObject?) -> [String:T]? {
-
-  if let dataDictionary = dataObject >>> JSONObjectsMap {
-    dictionary = [String:T]()
-
-    for (key, data) in dataDictionary {
-      dictionary![key] = T(data: data)
-    }
-  } else {
-    dictionary = nil
-  }
-  return dictionary
-}
-
-public func <<<<* <T: Deserializable>(inout dictionary: [String:T], dataObject: AnyObject?) -> [String: T] {
-  var newDictionary: [String:T]?
-  newDictionary <<<<* dataObject
-  if let newDictionary = newDictionary { dictionary = newDictionary }
-  return dictionary
 }
 
 // MARK: - Overloading of own operators for deserialization of JSON strings.

--- a/JSONHelperTests/JSONHelperTests.swift
+++ b/JSONHelperTests/JSONHelperTests.swift
@@ -21,9 +21,6 @@ class JSONHelperTests: XCTestCase {
     "stringArray": ["a", "b", "c"],
     "intArray": [1, 2, 3, 4, 5],
     "boolArray": [true, false],
-    "stringMap": ["m": "a", "n": "b", "o": "c"],
-    "intMap": ["m": 1, "n": 2, "o": 3, "p": 4, "q": 5],
-    "boolMap": ["m": true, "n": false],
     "instance": [
       "name": "b"
     ],
@@ -32,14 +29,6 @@ class JSONHelperTests: XCTestCase {
         "name": "c"
       ], [
         "name": "d"
-      ]
-    ],
-    "instanceDictionary": [
-      "m": [
-        "name": "e"
-      ],
-      "n": [
-        "name": "f"
       ]
     ]
   ]
@@ -171,24 +160,6 @@ class JSONHelperTests: XCTestCase {
     XCTAssertEqual(property.count, 2, "[Bool] property should have 2 members")
   }
 
-  func testStringMap() {
-    var property = [String: String]()
-    property <<<* dummyResponse["stringMap"]
-    XCTAssertEqual(property["m"]!, "a", "the value of [String: String][\"m\"] should be equal to 'a'")
-  }
-
-  func testIntMap() {
-    var property = [String: Int]()
-    property <<<* dummyResponse["intMap"]
-    XCTAssertEqual(property["m"]!, 1, "the value of [String: Int][\"m\"] should be equal to 1")
-  }
-
-  func testBoolMap() {
-    var property = [String: Bool]()
-    property <<<* dummyResponse["boolMap"]
-    XCTAssertEqual(property["m"]!, true, "the value of [String: Bool][\"m\"] should be true")
-  }
-
   func testInstance() {
     var instance = Person()
     instance <<<< dummyResponse["instance"]
@@ -199,12 +170,6 @@ class JSONHelperTests: XCTestCase {
     var property = [Person]()
     property <<<<* dummyResponse["instanceArray"]
     XCTAssertEqual(property.count, 2, "[Person] property should have 2 members")
-  }
-
-  func testInstanceDictionary() {
-    var property = [String: Person]()
-    property <<<<* dummyResponse["instanceDictionary"]
-    XCTAssertEqual(property["m"]!.name, "e", "the name of [String:Person][\"e\"] should be equal to 'e'")
   }
 
   func testJSONStringParsing() {

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Operator List
 | Operator  | Functionality                                                                                              |
 | --------- | ---------------------------------------------------------------------------------------------------------- |
 | __<<<__   | For deserializing data into primitive types, NSDate or NSURL.                                              |
-| __<<<*__  | For deserializing data into an array or dictionary of primitive types, NSDate or NSURL.                                  |
+| __<<<*__  | For deserializing data into an array of primitive types, NSDate or NSURL.                                  |
 | __<<<<__  | For deserializing data into an instance of a class. __Supports JSON strings__                              |
-| __<<<<*__ | For deserializing data into an array or dicrionary that contains instances of a certain class. __Supports JSON strings__ |
+| __<<<<*__ | For deserializing data into an array that contains instances of a certain class. __Supports JSON strings__ |
 
 Simple Tutorial
 --------------
@@ -51,27 +51,11 @@ Please take a good look at the operator list before you start reading this tutor
 	"books": [
 		{
 			"author": "Irvine Welsh",
-			"name": "Filth",
-			"translations": {
-				"fr": {
-					"localized-name": "saleté",
-					"print-run": 10000
-				},
-				"de": {
-					"localized-name": "Schmutz",
-					"print-run": 150000
-				}
-			}
+			"name": "Filth"		
 		},
 		{
 			"author": "Bret Easton Ellis",
-			"name": "American Psycho",
-			"translations": {
-				"de": {
-					"localized-name": "Amerikanisch Psychopath",
-					"print-run": 69000
-				}
-			}
+			"name": "American Psycho"
 		}	
 	]
 }
@@ -83,11 +67,6 @@ From this response it is clear that we have a book model similar to the implemen
 class Book {
 	var author: String?
 	var name: String?
-	var translations: [String:Translation]?
-}
-class Translation {
-	var localizedName: String?
-	var printRun: Int?
 }
 ```
 
@@ -97,21 +76,10 @@ We now have to make it extend the protocol __Deserializable__ and implement the 
 class Book: Deserializable {
 	var author: String? // You can also use let instead of var if you want.
 	var name: String?
-	var translations: [String:Translation]?
-
+	
 	required init(data: [String: AnyObject]) {
 		author <<< data["author"]
 		name <<< data["name"]
-		translations <<<<* data["translations"]
-	}
-}
-class Translation {
-	var localizedName: String?
-	var printRun: Int?
-
-	required init(data: [String: AnyObject]) {
-		localizedName <<< data["localized-name"]
-		printRun <<< data["print-run"]
 	}
 }
 ```


### PR DESCRIPTION
Reverts isair/JSONHelper#20. I've been a bit hasty at merging it but seems like the swift compiler gets confused with <<<* after adding support for dictionaries. Tests fail to even compile on Xcode 6.1.1 (6A2006).