### PR TITLE
Bugfix: for Release builds

### DIFF
--- a/JSONHelper.xcodeproj/xcshareddata/xcschemes/JSONHelper-iOS.xcscheme
+++ b/JSONHelper.xcodeproj/xcshareddata/xcschemes/JSONHelper-iOS.xcscheme
@@ -40,7 +40,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Release">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/JSONHelper/JSONHelper.swift
+++ b/JSONHelper/JSONHelper.swift
@@ -42,6 +42,7 @@ infix operator <-- { associativity right precedence 150 }
 // For optionals.
 public func <-- <T>(inout property: T?, value: AnyObject?) -> T? {
   var newValue: T?
+  ""
   if let unwrappedValue: AnyObject = value {
     // We unwrapped the given value successfully, try to convert.
     if let convertedValue = unwrappedValue as? T {


### PR DESCRIPTION
We discovered a bug when using JSONHelper in release builds. We have modified the tests to run in release builds to display the error and figured out a workaround until a more robust solution can be found. 